### PR TITLE
Override image name in -override.yaml files to add back tech-preview

### DIFF
--- a/cp-overrides.yaml
+++ b/cp-overrides.yaml
@@ -1,14 +1,17 @@
 schema_version: 1
+
+name: "jboss-eap-7-tech-preview/eap72-openshift"
+
 modules:
       repositories:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-16
+                  ref: sprint-22
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: sprint-16
+                  ref: sprint-22
 osbs:
       repository:
             name: containers/jboss-eap-7

--- a/dev-overrides.yaml
+++ b/dev-overrides.yaml
@@ -1,5 +1,7 @@
 schema_version: 1
 
+name: "jboss-eap-7-tech-preview/eap72-openshift"
+
 modules:
       repositories:
           - name: cct_module

--- a/rel-overrides.yaml
+++ b/rel-overrides.yaml
@@ -1,14 +1,17 @@
 schema_version: 1
+
+name: "jboss-eap-7-tech-preview/eap72-openshift"
+
 modules:
       repositories:
           - name: cct_module
             git:
                   url: https://github.com/jboss-openshift/cct_module.git
-                  ref: sprint-16
+                  ref: sprint-22
           - name: jboss-eap-modules
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  ref: sprint-16
+                  ref: sprint-22
 osbs:
       repository:
             name: containers/jboss-eap-7


### PR DESCRIPTION
This overrides the image name in the respective -override.yaml files to restore the -tech-preview value in the name prefix.

Signed-off-by: Ken Wills <kwills@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
